### PR TITLE
exfat: fix name_hash wrong on big_endian system

### DIFF
--- a/dir.c
+++ b/dir.c
@@ -439,7 +439,7 @@ int exfat_init_dir_entry(struct inode *inode, struct exfat_chain *p_dir,
 {
 	struct super_block *sb = inode->i_sb;
 	struct exfat_sb_info *sbi = EXFAT_SB(sb);
-	struct timespec64 ts = current_time(inode);
+	exfat_timespec_t ts = current_time(inode);
 	sector_t sector;
 	struct exfat_dentry *ep;
 	struct buffer_head *bh;

--- a/exfat_fs.h
+++ b/exfat_fs.h
@@ -22,6 +22,12 @@
 
 #define EXFAT_CLUSTERS_UNTRACKED (~0u)
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 18, 0)
+typedef struct timespec64 exfat_timespec_t;
+#else
+typedef struct timespec exfat_timespec_t;
+#endif
+
 /*
  * exfat error flags
  */
@@ -190,9 +196,9 @@ struct exfat_dir_entry {
 	unsigned short attr;
 	loff_t size;
 	unsigned int num_subdirs;
-	struct timespec64 atime;
-	struct timespec64 mtime;
-	struct timespec64 crtime;
+	exfat_timespec_t atime;
+	exfat_timespec_t mtime;
+	exfat_timespec_t crtime;
 	struct exfat_dentry_namebuf namebuf;
 };
 
@@ -303,7 +309,7 @@ struct exfat_inode_info {
 	struct rw_semaphore truncate_lock;
 	struct inode vfs_inode;
 	/* File creation time */
-	struct timespec64 i_crtime;
+	exfat_timespec_t i_crtime;
 };
 
 static inline struct exfat_sb_info *EXFAT_SB(struct super_block *sb)
@@ -530,10 +536,10 @@ void exfat_msg(struct super_block *sb, const char *lv, const char *fmt, ...)
 #define exfat_info(sb, fmt, ...)					\
 	exfat_msg(sb, KERN_INFO, fmt, ##__VA_ARGS__)
 
-void exfat_get_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
+void exfat_get_entry_time(struct exfat_sb_info *sbi, exfat_timespec_t *ts,
 		u8 tz, __le16 time, __le16 date, u8 time_cs);
-void exfat_truncate_atime(struct timespec64 *ts);
-void exfat_set_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
+void exfat_truncate_atime(exfat_timespec_t *ts);
+void exfat_set_entry_time(struct exfat_sb_info *sbi, exfat_timespec_t *ts,
 		u8 *tz, __le16 *time, __le16 *date, u8 *time_cs);
 u16 exfat_calc_chksum16(void *data, int len, u16 chksum, int type);
 u32 exfat_calc_chksum32(void *data, int len, u32 chksum, int type);

--- a/file.c
+++ b/file.c
@@ -150,7 +150,7 @@ int __exfat_truncate(struct inode *inode, loff_t new_size)
 
 	/* update the directory entry */
 	if (!evict) {
-		struct timespec64 ts;
+		exfat_timespec_t ts;
 		struct exfat_dentry *ep, *ep2;
 		struct exfat_entry_set_cache *es;
 

--- a/misc.c
+++ b/misc.c
@@ -64,7 +64,7 @@ void exfat_msg(struct super_block *sb, const char *level, const char *fmt, ...)
 #define SECS_PER_MIN    (60)
 #define TIMEZONE_SEC(x)	((x) * 15 * SECS_PER_MIN)
 
-static void exfat_adjust_tz(struct timespec64 *ts, u8 tz_off)
+static void exfat_adjust_tz(exfat_timespec_t *ts, u8 tz_off)
 {
 	if (tz_off <= 0x3F)
 		ts->tv_sec -= TIMEZONE_SEC(tz_off);
@@ -73,7 +73,7 @@ static void exfat_adjust_tz(struct timespec64 *ts, u8 tz_off)
 }
 
 /* Convert a EXFAT time/date pair to a UNIX date (seconds since 1 1 70). */
-void exfat_get_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
+void exfat_get_entry_time(struct exfat_sb_info *sbi, exfat_timespec_t *ts,
 		u8 tz, __le16 time, __le16 date, u8 time_cs)
 {
 	u16 t = le16_to_cpu(time);
@@ -99,7 +99,7 @@ void exfat_get_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
 }
 
 /* Convert linear UNIX date to a EXFAT time/date pair. */
-void exfat_set_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
+void exfat_set_entry_time(struct exfat_sb_info *sbi, exfat_timespec_t *ts,
 		u8 *tz, __le16 *time, __le16 *date, u8 *time_cs)
 {
 	struct tm tm;
@@ -129,7 +129,7 @@ void exfat_set_entry_time(struct exfat_sb_info *sbi, struct timespec64 *ts,
  * (There is no 10msIncrement field for access_time unlike create/modify_time)
  * atime also has only a 2-second resolution.
  */
-void exfat_truncate_atime(struct timespec64 *ts)
+void exfat_truncate_atime(exfat_timespec_t *ts)
 {
 	ts->tv_sec = round_down(ts->tv_sec, 2);
 	ts->tv_nsec = 0;

--- a/nls.c
+++ b/nls.c
@@ -518,7 +518,7 @@ static int exfat_utf8_to_utf16(struct super_block *sb,
 		    exfat_wstrchr(bad_uni_chars, *uniname))
 			lossy |= NLS_NAME_LOSSY;
 
-		upname[i] = exfat_toupper(sb, *uniname);
+		upname[i] = cpu_to_le16(exfat_toupper(sb, *uniname));
 		uniname++;
 	}
 
@@ -610,7 +610,7 @@ static int exfat_nls_to_ucs2(struct super_block *sb,
 		    exfat_wstrchr(bad_uni_chars, *uniname))
 			lossy |= NLS_NAME_LOSSY;
 
-		upname[unilen] = exfat_toupper(sb, *uniname);
+		upname[unilen] = cpu_to_le16(exfat_toupper(sb, *uniname));
 		uniname++;
 		unilen++;
 	}


### PR DESCRIPTION
Where read path failed on big endian system

tested on mips_24k qca9344